### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,6 +38,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,4 +1,6 @@
 name: Conventional Commit Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rshade/cronai/security/code-scanning/3](https://github.com/rshade/cronai/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Since the workflow only needs to read the repository contents to check commit messages, the minimal permission `contents: read` should be specified. This ensures the workflow operates with the least privileges necessary, reducing the risk of unintended actions.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
