### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -8,6 +8,9 @@ jobs:
   todo-to-issue:
     name: TODO to Issue
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/rshade/cronai/security/code-scanning/7](https://github.com/rshade/cronai/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. Since the `alstr/todo-to-issue-action` action interacts with issues, it requires `issues: write` permission. We will also include `contents: read` as a minimal permission for accessing the repository's contents. These permissions will be added at the job level to ensure they are scoped specifically to the `todo-to-issue` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
