### PR TITLE
ci(workflow): add pull-requests write permission to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,11 @@ Located in `internal/prompt` - Loads and prepares prompt files for submission to
 
 Located in `internal/processor` - Processes model responses (sending to email, Slack, webhooks, or saving to file).
 
+## Integration Testing Notes
+
+- **NEVER close GitHub issue #89** - This issue is used for GitHub integration tests and must remain open.
+- All GitHub processor tests utilize issue #89 to verify comment functionality.
+
 ## Environment Variables
 
 The application uses a `.env` file for configuration with the following variables:


### PR DESCRIPTION
Adds the pull-requests write permission to the integration-tests workflow to ensure that the GITHUB_TOKEN has sufficient permissions to interact with pull requests during integration tests.

This fixes the failing TestIntegration_APIKeys test by providing proper permissions for the GITHUB_TOKEN to be generated with the required scopes.

- Modified .github/workflows/integration-tests.yml to add pull-requests: write permission