### PR TITLE
feat(cli): add --mode flag stub for future operation modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The following features are in development and will be available in future releas
 - Webhook processor integration
 - Enhanced templating capabilities
 - Web UI for prompt management
+- Bot mode for event-driven webhook handling (stub available via `--mode bot`)
+- Queue mode for distributed task execution (stub available via `--mode queue`)
 
 See [limitations-and-improvements.md](docs/limitations-and-improvements.md) for a detailed breakdown of current limitations and planned improvements.
 
@@ -236,11 +238,18 @@ GITHUB_TOKEN=your_github_token
 ### Common Commands
 
 ```bash
-# Start the service with default config file
+# Start the service with default config file (cron mode)
 cronai start
+
+# Start with explicit operation mode (available since v0.0.2)
+cronai start --mode cron
 
 # Specify a custom config file
 cronai start --config /path/to/config
+
+# Future operation modes (coming soon)
+cronai start --mode bot    # Event-driven webhook handler (planned)
+cronai start --mode queue  # Job queue processor (planned)
 
 # Run a single task immediately
 cronai run --model openai --prompt system_health --processor file-health.log
@@ -255,7 +264,17 @@ cronai list
 cronai prompt list
 cronai prompt search "monitoring"
 cronai prompt show system/system_health
-```text
+```
+
+### Operation Modes
+
+As of v0.0.2, CronAI supports the `--mode` flag to prepare for future operation modes:
+
+- **cron** (default): Traditional scheduled task execution using cron syntax
+- **bot** (coming soon): Event-driven webhook handler for real-time responses
+- **queue** (coming soon): Job queue processor for distributed task execution
+
+The `--mode` flag establishes the CLI interface early, allowing users to prepare for future features without breaking changes.text
 
 ## Running as a systemd Service
 

--- a/cmd/cronai/cmd/start.go
+++ b/cmd/cronai/cmd/start.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var operationMode string
+
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the CronAI service",
@@ -22,22 +24,35 @@ Examples:
   0 8 * * * openai daily_summary email-report@company.com
   */30 * * * * claude system_monitor slack-ops-channel
   0 9 * * 1 gemini weekly_report file type=weekly,format=pdf`,
-	Example: `  # Start with default config file
+	Example: `  # Start with default config file (cron mode)
   cronai start
+
+  # Start with explicit cron mode
+  cronai start --mode cron
 
   # Start with custom config
   cronai start --config=/etc/cronai/production.config
 
+  # Future modes (not yet implemented)
+  cronai start --mode bot    # Event-driven webhook handler
+  cronai start --mode queue  # Job queue processor
+
   # Run in background (systemd)
   sudo systemctl start cronai`,
 	Run: func(_ *cobra.Command, _ []string) {
+		// Validate operation mode
+		if err := validateMode(operationMode); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+
 		// Get config file path
 		configPath := cfgFile
 		if configPath == "" {
 			configPath = "./cronai.config"
 		}
 
-		fmt.Printf("Starting CronAI service with config: %s\n", configPath)
+		fmt.Printf("Starting CronAI service in %s mode with config: %s\n", operationMode, configPath)
 
 		// Start the cron service
 		if err := cron.StartService(configPath); err != nil {
@@ -46,6 +61,25 @@ Examples:
 	},
 }
 
+// validateMode validates the operation mode flag
+func validateMode(mode string) error {
+	switch mode {
+	case "cron":
+		return nil
+	case "bot", "queue":
+		return fmt.Errorf("mode '%s' is not yet implemented (coming in future releases)", mode)
+	default:
+		return fmt.Errorf("invalid mode '%s': must be one of: cron, bot, queue", mode)
+	}
+}
+
 func init() {
 	rootCmd.AddCommand(startCmd)
+
+	startCmd.Flags().StringVar(&operationMode, "mode", "cron",
+		"Operation mode: cron (default), bot (future), queue (future)\n"+
+			"Available modes:\n"+
+			"  cron  - Traditional scheduled task execution (default)\n"+
+			"  bot   - Event-driven webhook handler (coming soon)\n"+
+			"  queue - Job queue processor (coming soon)")
 }

--- a/cmd/cronai/cmd/start_test.go
+++ b/cmd/cronai/cmd/start_test.go
@@ -53,11 +53,114 @@ func TestStartCommandExamples(t *testing.T) {
 		"cronai start",
 		"cronai start --config=/etc/cronai/production.config",
 		"sudo systemctl start cronai",
+		"cronai start --mode cron",
+		"cronai start --mode bot",
+		"cronai start --mode queue",
 	}
 
 	for _, expected := range expectedExamples {
 		if !strings.Contains(startCmd.Example, expected) {
 			t.Errorf("Expected Example to contain '%s'", expected)
+		}
+	}
+}
+
+func TestValidateMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid cron mode",
+			mode:    "cron",
+			wantErr: false,
+		},
+		{
+			name:    "bot mode not yet implemented",
+			mode:    "bot",
+			wantErr: true,
+			errMsg:  "mode 'bot' is not yet implemented (coming in future releases)",
+		},
+		{
+			name:    "queue mode not yet implemented",
+			mode:    "queue",
+			wantErr: true,
+			errMsg:  "mode 'queue' is not yet implemented (coming in future releases)",
+		},
+		{
+			name:    "invalid mode",
+			mode:    "invalid",
+			wantErr: true,
+			errMsg:  "invalid mode 'invalid': must be one of: cron, bot, queue",
+		},
+		{
+			name:    "empty mode should be invalid",
+			mode:    "",
+			wantErr: true,
+			errMsg:  "invalid mode '': must be one of: cron, bot, queue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMode(tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" {
+				if err.Error() != tt.errMsg {
+					t.Errorf("validateMode() error message = %v, want %v", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestModeFlagDefault(t *testing.T) {
+	// Reset the flag value to ensure test isolation
+	operationMode = ""
+
+	// Check that operationMode has the correct default value after flag parsing
+	flag := startCmd.Flags().Lookup("mode")
+	if flag == nil {
+		t.Fatal("Expected 'mode' flag to exist")
+	}
+
+	if flag.DefValue != "cron" {
+		t.Errorf("Expected default mode to be 'cron', got %s", flag.DefValue)
+	}
+}
+
+func TestModeFlagExists(t *testing.T) {
+	// Check that the mode flag exists
+	flag := startCmd.Flags().Lookup("mode")
+	if flag == nil {
+		t.Fatal("Expected 'mode' flag to exist on start command")
+	}
+
+	// Check flag properties
+	if flag.Name != "mode" {
+		t.Errorf("Expected flag name to be 'mode', got %s", flag.Name)
+	}
+
+	if flag.DefValue != "cron" {
+		t.Errorf("Expected default value to be 'cron', got %s", flag.DefValue)
+	}
+
+	// Check that the usage string mentions all modes
+	expectedUsageStrings := []string{
+		"Operation mode",
+		"cron",
+		"bot",
+		"queue",
+	}
+
+	for _, expected := range expectedUsageStrings {
+		if !strings.Contains(flag.Usage, expected) {
+			t.Errorf("Expected flag usage to contain '%s', usage: %s", expected, flag.Usage)
 		}
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,16 @@ CronAI is built as a modular Go application that connects scheduled tasks to AI 
 Configuration → Scheduling → Prompt Management → Model Execution → Response Processing
 ```text
 
+## Operation Modes (v0.0.2+)
+
+CronAI is designed to support multiple operation modes to accommodate different use cases:
+
+- **Cron Mode** (default, currently implemented): Traditional scheduled task execution using cron syntax
+- **Bot Mode** (planned): Event-driven webhook handler for real-time AI responses
+- **Queue Mode** (planned): Job queue processor for distributed task execution
+
+The `--mode` flag was introduced in v0.0.2 as a stub implementation to establish the CLI interface early, avoiding breaking changes when additional modes are implemented. Currently, only 'cron' mode is functional.
+
 ## Components Diagram
 
 ```text

--- a/docs/limitations-and-improvements.md
+++ b/docs/limitations-and-improvements.md
@@ -41,6 +41,7 @@ This document outlines the current limitations of CronAI's MVP release and plann
 - **Sequential Execution**: Tasks are executed sequentially without parallel processing capabilities.
 - **No Task Prioritization**: All tasks have equal priority with no queue management.
 - **No Execution History**: No persistent record of execution history beyond log files.
+- **Single Operation Mode**: Only cron mode is functional in the MVP (v0.0.2 adds `--mode` flag stub for future bot/queue modes).
 
 ### Security and Observability
 
@@ -113,6 +114,7 @@ This document outlines the current limitations of CronAI's MVP release and plann
 - **Distributed Task Execution**: Run tasks across multiple nodes.
 - **Horizontal Scaling**: Add capacity by adding more nodes.
 - **Execution Queues**: Prioritize and manage task execution.
+- **Operation Modes**: Bot and queue modes for event-driven and distributed processing (CLI stub available in v0.0.2).
 
 ### Q1 2026 - Enterprise Features
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -42,6 +42,8 @@ Update the following fields in the service file:
 - `User`: The user account that will run the service
 - `WorkingDirectory`: The directory where your configuration is located (e.g., `/etc/cronai`)
 - `ExecStart`: The path to the CronAI binary (e.g., `/usr/local/bin/cronai start --config /etc/cronai/cronai.config`)
+  - Since v0.0.2: You can also specify the operation mode with `--mode cron` (default)
+  - Future modes (bot, queue) will be available in upcoming releases
 - `EnvironmentFile`: The path to your .env file (e.g., `/etc/cronai/.env`)
 
 5. **Enable and start the service**

--- a/site-docs/docs/architecture.md
+++ b/site-docs/docs/architecture.md
@@ -14,6 +14,16 @@ CronAI is built as a modular Go application that connects scheduled tasks to AI 
 Configuration → Scheduling → Prompt Management → Model Execution → Response Processing
 ```
 
+## Operation Modes (v0.0.2+)
+
+CronAI is designed to support multiple operation modes to accommodate different use cases:
+
+- **Cron Mode** (default, currently implemented): Traditional scheduled task execution using cron syntax
+- **Bot Mode** (planned): Event-driven webhook handler for real-time AI responses
+- **Queue Mode** (planned): Job queue processor for distributed task execution
+
+The `--mode` flag was introduced in v0.0.2 as a stub implementation to establish the CLI interface early, avoiding breaking changes when additional modes are implemented. Currently, only 'cron' mode is functional.
+
 ## Components Diagram
 
 ```ascii

--- a/site-docs/docs/intro.md
+++ b/site-docs/docs/intro.md
@@ -37,6 +37,8 @@ The following features are in development and will be available in future releas
 - Webhook processor integration
 - Enhanced templating capabilities
 - Web UI for prompt management
+- Bot mode for event-driven webhook handling (stub available via `--mode bot` since v0.0.2)
+- Queue mode for distributed task execution (stub available via `--mode queue` since v0.0.2)
 
 See [Limitations and Improvements](https://github.com/rshade/cronai/blob/main/docs/limitations-and-improvements.md) for a detailed breakdown of current limitations and planned improvements.
 
@@ -90,3 +92,29 @@ timestamp model prompt response_processor [variables] [model_params:...]
 ```
 
 See the [Example Configuration Files](https://github.com/rshade/cronai/blob/main/cronai.config.example) in the repository for more examples.
+
+## Usage
+
+### Starting the Service
+
+```bash
+# Start with default config file (cron mode)
+cronai start
+
+# Start with explicit operation mode (available since v0.0.2)
+cronai start --mode cron
+
+# Future operation modes (coming soon)
+cronai start --mode bot    # Event-driven webhook handler (planned)
+cronai start --mode queue  # Job queue processor (planned)
+```
+
+### Operation Modes
+
+As of v0.0.2, CronAI supports the `--mode` flag to prepare for future operation modes:
+
+- **cron** (default): Traditional scheduled task execution using cron syntax
+- **bot** (coming soon): Event-driven webhook handler for real-time responses
+- **queue** (coming soon): Job queue processor for distributed task execution
+
+The `--mode` flag establishes the CLI interface early, allowing users to prepare for future features without breaking changes.

--- a/site-docs/docs/systemd.md
+++ b/site-docs/docs/systemd.md
@@ -46,6 +46,8 @@ Update the following fields in the service file:
 - `User`: The user account that will run the service
 - `WorkingDirectory`: The directory where your configuration is located (e.g., `/etc/cronai`)
 - `ExecStart`: The path to the CronAI binary (e.g., `/usr/local/bin/cronai start --config /etc/cronai/cronai.config`)
+  - Since v0.0.2: You can also specify the operation mode with `--mode cron` (default)
+  - Future modes (bot, queue) will be available in upcoming releases
 - `EnvironmentFile`: The path to your .env file (e.g., `/etc/cronai/.env`)
 
 ### 5. Enable and start the service


### PR DESCRIPTION
Adds a stub implementation of the `--mode` flag to the start command to prepare for future operation modes (bot and queue). This establishes the CLI interface early, avoiding breaking changes when these modes are fully implemented.

- Add --mode flag to start command with default value "cron"
- Implement validation that only allows "cron" mode currently
- Show friendly error messages for not-yet-implemented modes (bot, queue)
- Add comprehensive unit tests for mode flag functionality
- Update all documentation to reflect the new flag and planned modes
- Update site-docs with operation mode information

The flag accepts three values:
- cron (default): Traditional scheduled task execution
- bot (future): Event-driven webhook handler
- queue (future): Job queue processor

Closes #138